### PR TITLE
Fix suspicious int literal

### DIFF
--- a/src/ldap/lber.ml
+++ b/src/ldap/lber.ml
@@ -527,7 +527,7 @@ let encode_ber_int32 ?(cls=Universal) ?(tag=2) value =
               (Int32.logor (* flip what WILL be the sign bit in the encoded byte ON *)
                  0b1000_0000l
                  (Int32.logand (* flip the sign bit for the WHOLE word OFF *)
-                    0b00000000_00000000_00000000_1111111l
+                    0b00000000_00000000_00000000_11111111l
                     value)))
        else if value > 0b11111111_11111111_10000000_00000000l then
          (* fits in 15 bits + sign bit *)


### PR DESCRIPTION
fix https://github.com/kit-ty-kate/ocamldap/issues/4

Note that this change has no effect in practice because the extra bit was set unconditionally at line 528.

The following two expression should behave the same:
`logor (0b1000_0000 (logand a 0b0111_1111))`
`logor (0b1000_0000 (logand a 0b1111_1111))`
