### PR TITLE
Fix double escaping of backslashes

### DIFF
--- a/src/ldap/ldap_filterparser.mly
+++ b/src/ldap/ldap_filterparser.mly
@@ -22,11 +22,11 @@
 %{
   open Ldap_types
 
-  let star_escape_rex = Re.compile (Re.str ("\\" ^ "\\2a"))
-  let lparen_escape_rex = Re.compile (Re.str ("\\" ^ "\\28"))
-  let rparen_escape_rex = Re.compile (Re.str ("\\" ^ "\\29"))
-  let backslash_escape_rex = Re.compile (Re.str ("\\" ^ "\\5c"))
-  let null_escape_rex = Re.compile (Re.str ("\\" ^ "\\00"))
+  let star_escape_rex = Re.compile (Re.str "\\2a")
+  let lparen_escape_rex = Re.compile (Re.str "\\28")
+  let rparen_escape_rex = Re.compile (Re.str "\\29")
+  let backslash_escape_rex = Re.compile (Re.str "\\5c")
+  let null_escape_rex = Re.compile (Re.str "\\00")
   let unescape s =
     (Re.replace_string star_escape_rex ~by:"*"
        (Re.replace_string lparen_escape_rex ~by:"("


### PR DESCRIPTION
In 74b667ef228ec0db823c6dcd260117d39450caac, calls to Re.Pcre.regexp were directly replaced by Re.str, but they do not have the same semantics: Re.str matches a litteral string, whereas Re.Pcre.regexp matches a regexp.