### PR TITLE
Use base64 instead of ocamlnet.

### DIFF
--- a/ldap.opam
+++ b/ldap.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/kit-ty-kate/ocamldap"
 doc: "https://kit-ty-kate.github.io/ocamldap"
 bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
 depends: [
-  "base64"
+  "base64" {>= "3.0.0"}
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03.0"}
   "re" {>= "1.3.0"}

--- a/ldap.opam
+++ b/ldap.opam
@@ -9,9 +9,9 @@ homepage: "https://github.com/kit-ty-kate/ocamldap"
 doc: "https://kit-ty-kate.github.io/ocamldap"
 bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
 depends: [
+  "base64"
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03.0"}
-  "ocamlnet" {>= "3.6.0"}
   "re" {>= "1.3.0"}
   "camlp-streams" {>= "5.0.1"}
   "ssl" {>= "0.5.3"}

--- a/src/ldap/dune
+++ b/src/ldap/dune
@@ -6,4 +6,4 @@
   (public_name ldap)
   (wrapped false)
   (modules_without_implementation ldap_urlparser)
-  (libraries str camlp-streams re ssl))
+  (libraries unix str camlp-streams re ssl))

--- a/src/ldif/dune
+++ b/src/ldif/dune
@@ -6,6 +6,4 @@
   (public_name ldap.ldif)
   (wrapped false)
   (modules_without_implementation ldif_types)
-  (libraries camlp-streams ldap threads netstring))
-
-; TODO: remove threads. See https://gitlab.camlcity.org/gerd/lib-ocamlnet3/issues/14
+  (libraries camlp-streams ldap str base64))

--- a/src/ldif/ldif_changerec_lexer.mll
+++ b/src/ldif/ldif_changerec_lexer.mll
@@ -20,7 +20,6 @@
 
 {
   open Ldif_changerec_parser
-  open Netencoding
 }
 
 let nl = '\n'
@@ -41,7 +40,7 @@ rule lexcr = parse
   | "delete:" mustsp (attrname as name) nl {Delete name}
   | "replace:" mustsp (attrname as name) nl {Replace name}
   | (attrname as attr) ':' mustsp (attrval as valu) nl {Attr (attr, valu)}
-  | (attrname as attr) "::" mustsp (attrval as valu) nl {Attr (attr, Base64.decode valu)}
+  | (attrname as attr) "::" mustsp (attrval as valu) nl {Attr (attr, Base64.decode_exn valu)}
   | '-' nl {Dash}
   | nl + {Newline}
   | eof {End_of_input}

--- a/src/ldif/ldif_oo.ml
+++ b/src/ldif/ldif_oo.ml
@@ -21,7 +21,6 @@
 *)
 
 
-open Netencoding
 open Ldap_ooclient
 open Ldif_parser
 
@@ -44,14 +43,14 @@ let safe_val buf s =
   end
   else begin
     Buffer.add_string buf ":: ";
-    Buffer.add_string buf (Base64.encode s)
+    Buffer.add_string buf (Base64.encode_exn s)
   end
 
 let safe_attr_val buf a v =
   if Str.string_match password_regex a 0 then begin
     Buffer.add_string buf a;
     Buffer.add_string buf ":: ";
-    Buffer.add_string buf (Base64.encode v)
+    Buffer.add_string buf (Base64.encode_exn v)
   end
   else begin
     Buffer.add_string buf a;

--- a/src/ldif/ldif_parser.ml
+++ b/src/ldif/ldif_parser.ml
@@ -21,7 +21,6 @@
 
 
 open Ldap_types
-open Netencoding
 
 exception Illegal_char of char * int
 exception End
@@ -165,7 +164,7 @@ let value_spec s =
       ':' -> (Stream.junk s.stream);
         (match (optval (Stream.peek s.stream)) with
              ' ' -> (Stream.junk s.stream);
-               (Base64.decode (safe_string s))
+               (Base64.decode_exn (safe_string s))
            |  c  -> raise (Illegal_char (c, s.line)))
     | '<' -> (Stream.junk s.stream);(match (optval (Stream.peek s.stream)) with
                                   ' ' -> (Stream.junk s.stream);(safe_string s) (* a url *)
@@ -200,7 +199,7 @@ let distinguishedName s =
       ':' -> (Stream.junk s.stream);
         (match (optval (Stream.peek s.stream)) with
              ' ' -> (Stream.junk s.stream);
-               (Base64.decode (safe_string s))
+               (Base64.decode_exn (safe_string s))
            |  c  -> raise (Illegal_char (c, s.line)))
     | ' ' -> (Stream.junk s.stream);safe_string s
     |  c  -> raise (Illegal_char (c, s.line))

--- a/tests/ldap/dune
+++ b/tests/ldap/dune
@@ -1,6 +1,6 @@
 (executables
   (names test page_result_control_test lber_tests)
-  (libraries ldap))
+  (libraries unix ldap))
 
 (rule
   (alias runtest)


### PR DESCRIPTION
ocamlnet seems to be unmaintained (in particular it does not compile with ocaml 5...) and used here only for base64 encoding/decoding. I suggest replacing it by [ocaml-base64](https://github.com/mirage/ocaml-base64) which is maintained and much more leightweight as a dependency.